### PR TITLE
update irc page

### DIFF
--- a/site/irc.txt
+++ b/site/irc.txt
@@ -27,9 +27,9 @@ list of public logs:
 - (@cem) https://irclogs.carbslinux.org/kisslinux/
 - (@acheam) https://irclogs.armaanb.net/kisslinux/
 
-Unfortunately, the above sources don't contain any logs from before
-#kisslinux switched to Libera. For an archive of previous logs from
-Freenode, see https://freenode.logbot.info/kisslinux/.
+Some but not all of the above sources contain logs from before #kisslinux
+switched to Libera. For an archive of previous logs from Freenode, see
+https://archive.logbot.info/.
 
 
 [3.0] IRC Etiquette

--- a/site/irc.txt
+++ b/site/irc.txt
@@ -22,7 +22,8 @@ The IRC channel is publicly logged by a few of the channel denizens. Here are a
 list of public logs:
 
 - https://libera.irclog.whitequark.org/kisslinux/
-- (@phoebos) https://gemini.ctrl-c.club/~phoebos/logs/
+- (@phoebos) https://ctrl-c.club/~phoebos/logs/
+- (@phoebos) gemini://gemini.ctrl-c.club/~phoebos/logs/
 - (@cem) https://irclogs.carbslinux.org/kisslinux/
 - (@acheam) https://irclogs.armaanb.net/kisslinux/
 


### PR DESCRIPTION
ctrl-c.club's SSL cert is now back, so there is now https access on https://ctrl-c.club/ as well as https://gemini.ctrl-c.club/. The former is shorter and looks nicer, in my opinion.

Also, https://freenode.logbot.info is now taken down, so link to the archive site instead.